### PR TITLE
Throw error if no directory argument provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,21 +122,23 @@ const createPackage = (options) => {
 
   const cwd = process.cwd();
 
+  let packageDir = process.argv[2];
+
+  if (!packageDir) {
+    console.error(
+      chalk.red("Must provide directory as an argument.")
+    );
+    process.exit(1);
+  }
+  
   // Follow the `@types/scope__name` convention for replacing `/`.
-  let packageDir = process.argv[2].replace(/\//g, "__");
+  packageDir = process.argv[2].replace(/\//g, "__");
 
   options.name = options.name || packageDir;
 
   const createFileParams = makeCreateFileParams(options);
 
   const { nameWithScope, dirName } = createFileParams;
-
-  if (!packageDir) {
-    console.log(
-      "Must provide directory as argument: `npm init " + node + " my-app`."
-    );
-    process.exit(1);
-  }
 
   if (isSubPackage) {
     packageDir = `${packageDir}/packages/${dirName}`;


### PR DESCRIPTION
Fixes #1.

This PR does a few things:

* Check for the presence of `process.argv[2]` and throw an error if no arguments given
* Throws this error earlier, before string replacement attempted on `process.argv[2]`
* Removes undefined `node` variable in error message

On that last point, I’m stuck how to get the name of the create package to return a more helpful error message as originally intended. `process.argv[1]` provides a path to the executable, but I’m not sure how reliable that is as a source of what the name originally entered into the CLI would be.

According to the npm docs, multiple package names are valid create initialisers:

* `npm init foo` -> `npm exec create-foo`
* `npm init @usr/foo` -> `npm exec @usr/create-foo`
* `npm init @usr` -> `npm exec @usr/create`
* `npm init @usr@2.0.0` -> `npm exec @usr/create@2.0.0`
* `npm init @usr/foo@2.0.0` -> `npm exec @usr/create-foo@2.0.0`

It may be possible to parse the path in `process.argv[1]`, but I’m not sure how each the above examples would look. You’d also need to reliably remove `create-` (or `/create` for scoped packages).

Maybe there’s an npm package that could be used to infer the above, but I note that this package has zero production dependencies, and it’d be nice to keep it that way.

@AndersDJohnson Do you have ideas?